### PR TITLE
Don’t get configuration from the environment; leave that up to the caller.

### DIFF
--- a/application.go
+++ b/application.go
@@ -207,12 +207,12 @@ type DataErrorMessage string
 // Error messages are sent on the error channel that is returned.
 func (app *Application) DataStream() (chan DataMessage, chan DataErrorMessage, error) {
 
-	congressURL, err := url.Parse(app.client.Endpoint)
+	congressURL, err := url.Parse(app.client.Addr)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	wscfg, err := websocket.NewConfig(fmt.Sprintf("ws://%s/applications/%s/stream", congressURL.Host, app.EUI), "http://example.com")
+	wscfg, err := websocket.NewConfig(fmt.Sprintf("wss://%s/applications/%s/stream", congressURL.Host, app.EUI), "http://example.com")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/application_test.go
+++ b/application_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestApplications(t *testing.T) {
-	client, err := NewCongressClient(EnvironmentToken)
+	client, err := NewCongressClientWithAddr(*addr, *token)
 	if err != nil {
 		t.Fatalf("Got error creating client: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestApplications(t *testing.T) {
 }
 
 func TestAppOutput(t *testing.T) {
-	client, _ := NewCongressClient(EnvironmentToken)
+	client, _ := NewCongressClientWithAddr(*addr, *token)
 	app, _ := client.NewApplication()
 
 	mqtt1 := &MQTTConfig{
@@ -167,7 +167,7 @@ func TestAppOutput(t *testing.T) {
 
 // Test the websocket output. There's no easy way to generate output
 func TestWebsocketOutput(t *testing.T) {
-	client, _ := NewCongressClient(EnvironmentToken)
+	client, _ := NewCongressClientWithAddr(*addr, *token)
 	app, _ := client.NewApplication()
 	d1, _ := app.NewDevice(OTAA)
 	d2, _ := app.NewDevice(ABP)

--- a/device_test.go
+++ b/device_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestDevices(t *testing.T) {
-	client, err := NewCongressClient(EnvironmentToken)
+	client, err := NewCongressClientWithAddr(*addr, *token)
 	if err != nil {
 		t.Fatalf("Couldn't create Congress client: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestDevices(t *testing.T) {
 }
 
 func TestDownstreamMessages(t *testing.T) {
-	client, err := NewCongressClient(EnvironmentToken)
+	client, err := NewCongressClientWithAddr(*addr, *token)
 	if err != nil {
 		t.Fatalf("Couldn't create Congress client: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestDownstreamMessages(t *testing.T) {
 
 // Create a lot of devices, then update them individually
 func TestMultipleDevices(t *testing.T) {
-	client, _ := NewCongressClient(EnvironmentToken)
+	client, _ := NewCongressClientWithAddr(*addr, *token)
 	app, _ := client.NewApplication()
 
 	devices := make([]*Device, 10)

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -32,7 +32,7 @@ func randomEUI() string {
 }
 
 func TestGateway(t *testing.T) {
-	client, err := NewCongressClient(EnvironmentToken)
+	client, err := NewCongressClientWithAddr(*addr, *token)
 	if err != nil {
 		t.Fatalf("Got error creating client: %v", err)
 	}


### PR DESCRIPTION
Flags can be passed to tests with `go test -args <args>`.  There are now such flags for address and token.

Also use secure websocket protocol.